### PR TITLE
Expose Pydantic objects in public API

### DIFF
--- a/src/hqar/__init__.py
+++ b/src/hqar/__init__.py
@@ -11,9 +11,10 @@ Public API of HQAR.
 """
 from typing import Any
 
-from ._schema_v1 import generate_schema_v1
+from ._schema_v1 import SchemaV1, generate_schema_v1
 
 SCHEMA_GENERATORS = {"v1": generate_schema_v1}
+MODELS = {"v1": SchemaV1}
 LATEST_SCHEMA_VERSION = "v1"
 
 
@@ -35,4 +36,4 @@ def generate_program_schema(version: str = LATEST_SCHEMA_VERSION) -> dict[str, A
         raise ValueError(f"Unknown schema version {version}")
 
 
-__all__ = ["generate_program_schema"]
+__all__ = ["generate_program_schema", "SchemaV1"]

--- a/tests/hqar/test_schema_validation.py
+++ b/tests/hqar/test_schema_validation.py
@@ -11,11 +11,12 @@ Test cases checking that schema matches data that we expect it to match.
 """
 from pathlib import Path
 
+import pydantic
 import pytest
 import yaml  # type: ignore[import-untyped]
 from jsonschema import ValidationError, validate
 
-from hqar import generate_program_schema
+from hqar import SchemaV1, generate_program_schema
 
 
 def validate_with_v1(data):
@@ -45,7 +46,7 @@ def load_valid_examples():
 
 
 @pytest.mark.parametrize("input, error_path, error_message", load_invalid_examples())
-def test_invalid_schema_fail_to_validate(input, error_path, error_message):
+def test_invalid_program_fails_to_validate_with_schema_v1(input, error_path, error_message):
     with pytest.raises(ValidationError) as err_info:
         validate_with_v1(input)
 
@@ -54,5 +55,16 @@ def test_invalid_schema_fail_to_validate(input, error_path, error_message):
 
 
 @pytest.mark.parametrize("input", load_valid_examples())
-def test_valid_schema_fail_to_validate(input):
+def test_valid_program_fails_to_validate_with_schema_v1(input):
     validate_with_v1(input)
+
+
+@pytest.mark.parametrize("input", [input for input, *_ in load_invalid_examples()])
+def test_invalid_program_fails_to_validate_with_pydantic_model_v1(input):
+    with pytest.raises(pydantic.ValidationError):
+        SchemaV1.model_validate(input)
+
+
+@pytest.mark.parametrize("input", load_valid_examples())
+def test_valid_program_succesfully_validate_with_pydantic_model_v1(input):
+    SchemaV1.model_validate(input)


### PR DESCRIPTION
This PR exposes Pydantic `SchemaV1` model as public component in HQAR API. In addition, validation using Pydantic models is also tested.