### PR TITLE
Add py.typed marker

### DIFF
--- a/src/qref/experimental/__init__.py
+++ b/src/qref/experimental/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-


### PR DESCRIPTION
This adds `py.typed` marker so that the `qref` packages is recognized as containing type hints. The solutions was tested locally by creating a sdist, installing it in a fresh venv and then confirming this mypy can use type hints from `qref`. 

Note that:
- `py.typed` is recursive, so it's only needed at the top-level `qref package`
- Since we are using poetry, it is automatically distributed (like any other file in the package). This might not be the case for other distribution systems.