### PR TITLE
chore: fix installation of precommit hooks

### DIFF
--- a/.github/workflows/quality_checks.yaml
+++ b/.github/workflows/quality_checks.yaml
@@ -50,6 +50,7 @@ jobs:
         run: |
           poetry install
           pip install pre-commit 
+          pre-commit install
           pre-commit install --hook-type commit-msg
           pre-commit run -a
       - name: Run mypy


### PR DESCRIPTION
As it turns out, if you just run `pre-commit install --hook-type commit-msg`, it only installs `commit-msg`, without installing the rest, so this is needed to fix it.