### PR TITLE
refactor!: Convert local_variables from list of strings to dictionary

### DIFF
--- a/docs/examples/alias_sampling.yaml
+++ b/docs/examples/alias_sampling.yaml
@@ -3,7 +3,7 @@ program:
   - input_params:
     - L
     local_variables:
-    - R=ceiling(log_2(L))
+      R: ceiling(log_2(L))
     name: usp
     ports:
     - direction: input
@@ -33,7 +33,7 @@ program:
     - L
     - mu
     local_variables:
-    - R=ceiling(log_2(L))
+      R: ceiling(log_2(L))
     name: qrom
     ports:
     - direction: input
@@ -168,7 +168,7 @@ program:
     - qrom.mu
     - compare.mu
   local_variables:
-  - R=ceiling(log_2(L))
+    R: ceiling(log_2(L))
   name: alias_sampling
   ports:
   - direction: input

--- a/src/qref/schema_v1.py
+++ b/src/qref/schema_v1.py
@@ -106,7 +106,7 @@ class RoutineV1(BaseModel):
     resources: Annotated[list[ResourceV1], _name_sorter] = Field(default_factory=list)
     connections: Annotated[list[ConnectionV1], _source_sorter] = Field(default_factory=list)
     input_params: list[_OptionallyMultiNamespacedName] = Field(default_factory=list)
-    local_variables: list[str] = Field(default_factory=list)
+    local_variables: dict[str, str] = Field(default_factory=dict)
     linked_params: Annotated[list[ParamLinkV1], _source_sorter] = Field(default_factory=list)
     meta: dict[str, Any] = Field(default_factory=dict)
 

--- a/tests/qref/data/invalid_yaml_programs.yaml
+++ b/tests/qref/data/invalid_yaml_programs.yaml
@@ -228,4 +228,13 @@
   description: "Target of a paramater link is not namespaced"
   error_path: "$.program.linked_params[0].targets[0]"
   error_message: "'N' does not match '^([A-Za-z_][A-Za-z0-9_]*\\\\.)+[A-Za-z_][A-Za-z0-9_]*$'"
-  
+- input:
+    version: v1
+    program:
+      name: "root"
+      input_params:
+        - N
+      local_variables: ["R = N+1"]
+  description: Routine uses old format for local_variables
+  error_path: "$.program.local_variables"
+  error_message: "['R = N+1'] is not of type 'object'"

--- a/tests/qref/data/valid_programs/example_5.yaml
+++ b/tests/qref/data/valid_programs/example_5.yaml
@@ -1,0 +1,18 @@
+description: Program with local variables
+input:
+  program:
+    input_params:
+    - N
+    - M
+    name: root
+    ports:
+    - direction: input
+      name: in_0
+      size: N
+    - direction: output
+      name: out_0
+      size: 2
+    local_variables:
+      L: ceil(N/2)
+      R: M+2
+  version: v1


### PR DESCRIPTION
## Description

As stated in PsiQ/bartiq#71, we want to change from representing `local_variables` from list of strings of the form `var=expr` to a dictionary mapping variables to corresponding expressions. This PR introduces this change to Qref, so there is no discrepancy between Qref and Bartiq.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.