### PR TITLE
Fix issues with connection validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,3 +51,9 @@ target-version = ['py39']
 [[tool.mypy.overrides]]
 module = "graphviz.*"
 ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+markers = [
+    "invalid_schema_examples",
+    "invalid_pydantic_examples"
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,14 +57,11 @@ def pytest_generate_tests(metafunc):
                     id=example["description"],
                 )
                 for example in data
-            ]
+            ],
         )
     elif "invalid_pydantic_examples" in marker_names:
         data = [
             example["input"]
-            for example in (
-                _load_yaml(INVALID_YAML_PROGRAMS_PATH) +
-                _load_yaml(INVALID_PYDANTIC_PROGRAMS_PATH)
-            )
+            for example in (_load_yaml(INVALID_YAML_PROGRAMS_PATH) + _load_yaml(INVALID_PYDANTIC_PROGRAMS_PATH))
         ]
         metafunc.parametrize("input", data)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,13 +13,16 @@
 # limitations under the License.
 
 """Common fixtures for QREF tests."""
-
+from functools import lru_cache
 from pathlib import Path
 
 import pytest
 import yaml
 
-VALID_PROGRAMS_ROOT_PATH = Path(__file__).parent / "qref/data/valid_programs"
+DATA_ROOT_PATH = Path(__file__).parent / "qref/data"
+VALID_PROGRAMS_ROOT_PATH = DATA_ROOT_PATH / "valid_programs"
+INVALID_YAML_PROGRAMS_PATH = DATA_ROOT_PATH / "invalid_yaml_programs.yaml"
+INVALID_PYDANTIC_PROGRAMS_PATH = DATA_ROOT_PATH / "invalid_pydantic_programs.yaml"
 
 
 def _load_valid_examples():
@@ -32,3 +35,36 @@ def _load_valid_examples():
 @pytest.fixture(params=_load_valid_examples())
 def valid_program(request):
     return request.param
+
+
+@lru_cache(maxsize=None)
+def _load_yaml(path):
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def pytest_generate_tests(metafunc):
+    marker_names = [marker.name for marker in metafunc.definition.iter_markers()]
+    if "invalid_schema_examples" in marker_names:
+        data = _load_yaml(INVALID_YAML_PROGRAMS_PATH)
+        metafunc.parametrize(
+            "input, error_path, error_message",
+            [
+                pytest.param(
+                    example["input"],
+                    example["error_path"],
+                    example["error_message"],
+                    id=example["description"],
+                )
+                for example in data
+            ]
+        )
+    elif "invalid_pydantic_examples" in marker_names:
+        data = [
+            example["input"]
+            for example in (
+                _load_yaml(INVALID_YAML_PROGRAMS_PATH) +
+                _load_yaml(INVALID_PYDANTIC_PROGRAMS_PATH)
+            )
+        ]
+        metafunc.parametrize("input", data)

--- a/tests/qref/data/invalid_pydantic_programs.yaml
+++ b/tests/qref/data/invalid_pydantic_programs.yaml
@@ -23,5 +23,39 @@
         - source: foo.out_0
           target: bar.in_1
   description: "Connection contains non-existent port name"
-  error_path: "$.program.connections[0].source"
-  error_message: "'foo.foo.out_0' does not match '^(([A-Za-z_][A-Za-z0-9_]*)|([A-Za-z_][A-Za-z0-9_]*\\\\.[A-Za-z_][A-Za-z0-9_]*))$'"
+- input:
+    version: v1
+    program:
+      name: root
+      children:
+        - name: foo
+          ports:
+            - name: in_0
+              direction: inpt  # Warning: intentional typo here!
+              size: 1
+            - name: out_0
+              direction: output
+              size: 1
+        - name: bar
+          ports:
+            - name: in_0
+              direction: input
+              size: 1
+            - name: out_0
+              direction: output
+              size: 1
+      ports:
+        - name: in_0
+          direction: input
+          size: 1
+        - name: out_0
+          direction: output
+          size: 1
+      connections:
+        - source: in_0
+          target: foo.in_0
+        - source: foo.out_0
+          target: bar.in_0
+        - source: bar.oout_0  # Warning: intentional typo here!
+          target: out_0
+  description: "Validation error in child and in connections."

--- a/tests/qref/test_schema_validation.py
+++ b/tests/qref/test_schema_validation.py
@@ -26,27 +26,7 @@ def validate_with_v1(data):
     validate(data, generate_program_schema(version="v1"))
 
 
-def load_invalid_examples(add_pydantic=False):
-    with open(Path(__file__).parent / "data/invalid_yaml_programs.yaml") as f:
-        data = yaml.safe_load(f)
-
-    if add_pydantic:
-        with open(Path(__file__).parent / "data/invalid_pydantic_programs.yaml") as f:
-            additional_data = yaml.safe_load(f)
-        data += additional_data
-
-    return [
-        pytest.param(
-            example["input"],
-            example["error_path"],
-            example["error_message"],
-            id=example["description"],
-        )
-        for example in data
-    ]
-
-
-@pytest.mark.parametrize("input, error_path, error_message", load_invalid_examples())
+@pytest.mark.invalid_schema_examples
 def test_invalid_program_fails_to_validate_with_schema_v1(input, error_path, error_message):
     with pytest.raises(ValidationError) as err_info:
         validate_with_v1(input)
@@ -59,10 +39,11 @@ def test_valid_program_successfully_validates_with_schema_v1(valid_program):
     validate_with_v1(valid_program)
 
 
-@pytest.mark.parametrize("input", [input for input, *_ in load_invalid_examples(add_pydantic=True)])
+@pytest.mark.invalid_pydantic_examples
 def test_invalid_program_fails_to_validate_with_pydantic_model_v1(input):
-    with pytest.raises(pydantic.ValidationError):
+    with pytest.raises(pydantic.ValidationError) as e:
         SchemaV1.model_validate(input)
+    print(e.value)
 
 
 def test_valid_program_succesfully_validate_with_pydantic_model_v1(valid_program):

--- a/tests/qref/test_schema_validation.py
+++ b/tests/qref/test_schema_validation.py
@@ -11,12 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from pathlib import Path
-
 import pydantic
 import pytest
-import yaml  # type: ignore[import-untyped]
 from jsonschema import ValidationError, validate
 
 from qref import SchemaV1, generate_program_schema


### PR DESCRIPTION
## Description

Currently, we use `field_validator` for validating if all endpoints in all connections exist. However, the problem with this approach is that it relies on `children` of a routine being successfully validated prior to validating connections. In a likely event that a child fails to validate, the "children" key will not be present in validation data, and the validator for connections will fail with a `TypeError`. This PR fixes this by reimplementing connection validator as `model_validator` that runs iff per-field builtin validators run successfully (otherwise validating connection endpoints is meaningless).

In addition, this PR fixes a hidden problem of incorrect loading of negative testcases for pydantic model validation. Currently, those tests passed trivially (!) because the loaded data consisted of tuples instead of dictionaries.

The documentation has not been updated because the changes are not user-facing, and modified internal parts are not described in the docs.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.