### PR TITLE
feat: Allow more concise definition of connections

### DIFF
--- a/docs/examples/basic_program_concise.yaml
+++ b/docs/examples/basic_program_concise.yaml
@@ -1,0 +1,27 @@
+version: v1
+program:
+  name: my_program
+  ports:
+    - { direction: input, name: in_0, size: 1 }
+    - { direction: input, name: in_1, size: 2 }
+    - { direction: output, name: out, size: 3 }
+  children:
+    - name: subroutine_1
+      ports:
+        - { direction: input, name: in, size: 1 }
+        - { direction: output, name: out, size: 1 }
+    - name: subroutine_2
+      ports:
+        - { direction: input, name: in, size: 2 }
+        - { direction: output, name: out, size: 2 }
+    - name: merge
+      ports:
+        - { direction: input, name: in_0, size: 1 }
+        - { direction: input, name: in_1, size: 2 }
+        - { direction: output, name: out, size: 3 }
+  connections:
+    - "in_0 -> subtourine_1.in"
+    - "in_1 -> subroutine_2.in"
+    - "subroutine_1.out -> merge.in_1"
+    - "subroutine_2.out -> merge.in_0"
+    - "merge.out -> out"

--- a/docs/format.md
+++ b/docs/format.md
@@ -132,3 +132,23 @@ There are three types of connections:
   ```yaml
   {source: in_0, target: out}
   ```
+
+Writing connections in this way migh be cumbersome. However, there exists
+an alternative, more concise syntax. Instead writing:
+
+```yaml
+{source: a.out, target: b.in}
+```
+you can write:
+```
+"a.out -> b.in"
+```
+
+With this concise notation, the example program we've seen at the very
+beginning looks as follows:
+
+=== "YAML"
+
+    ```yaml
+    --8<-- "basic_program_concise.yaml"
+    ```

--- a/src/qref/schema_v1.py
+++ b/src/qref/schema_v1.py
@@ -21,6 +21,7 @@ from typing import Annotated, Any, Literal, Optional, Union
 from pydantic import (
     AfterValidator,
     BaseModel,
+    BeforeValidator,
     ConfigDict,
     Field,
     StringConstraints,
@@ -30,17 +31,17 @@ from pydantic.json_schema import GenerateJsonSchema
 from typing_extensions import Self
 
 NAME_PATTERN = "[A-Za-z_][A-Za-z0-9_]*"
-OPTIONALLY_NAMESPACED_NAME_PATTERN = rf"^({NAME_PATTERN}\.)?{NAME_PATTERN}$"
-MULTINAMESPACED_NAME_PATTERN = rf"^({NAME_PATTERN}\.)+{NAME_PATTERN}$"
-OPTIONALLY_MULTINAMESPACED_NAME_PATTERN = rf"^({NAME_PATTERN}\.)*{NAME_PATTERN}$"
+OPTIONALLY_NAMESPACED_NAME_PATTERN = rf"({NAME_PATTERN}\.)?{NAME_PATTERN}"
+MULTINAMESPACED_NAME_PATTERN = rf"({NAME_PATTERN}\.)+{NAME_PATTERN}"
+OPTIONALLY_MULTINAMESPACED_NAME_PATTERN = rf"({NAME_PATTERN}\.)*{NAME_PATTERN}"
+CONNECTON_PATTERN = rf"{OPTIONALLY_MULTINAMESPACED_NAME_PATTERN} -> {OPTIONALLY_MULTINAMESPACED_NAME_PATTERN}"
 
 _Name = Annotated[str, StringConstraints(pattern=rf"^{NAME_PATTERN}$")]
-_OptionallyNamespacedName = Annotated[str, StringConstraints(pattern=rf"{OPTIONALLY_NAMESPACED_NAME_PATTERN}")]
-_MultiNamespacedName = Annotated[str, StringConstraints(pattern=rf"{MULTINAMESPACED_NAME_PATTERN}")]
+_OptionallyNamespacedName = Annotated[str, StringConstraints(pattern=rf"^{OPTIONALLY_NAMESPACED_NAME_PATTERN}$")]
+_MultiNamespacedName = Annotated[str, StringConstraints(pattern=rf"^{MULTINAMESPACED_NAME_PATTERN}$")]
 _OptionallyMultiNamespacedName = Annotated[
-    str, StringConstraints(pattern=rf"{OPTIONALLY_MULTINAMESPACED_NAME_PATTERN}")
+    str, StringConstraints(pattern=rf"^{OPTIONALLY_MULTINAMESPACED_NAME_PATTERN}$")
 ]
-
 _Value = Union[int, float, str]
 
 
@@ -53,6 +54,35 @@ def _sorter(key):
 
 _name_sorter = AfterValidator(_sorter(lambda p: p.name))
 _source_sorter = AfterValidator(_sorter(lambda c: c.source))
+
+
+def _parse_connection(connection):
+    if isinstance(connection, str):
+        source, target = connection.replace(" ", "").split("->")
+        return {"source": source, "target": target}
+    return connection
+
+
+_connection_parser = BeforeValidator(_parse_connection)
+
+
+CONNECTION_SCHEMA = {
+    "type": "array",
+    "items": {
+        "anyOf": [
+            {"$ref": "#/$defs/Connection"},
+            {
+                "pattern": (
+                    "^([A-Za-z_][A-Za-z0-9_]*\\.)*[A-Za-z_][A-Za-z0-9_]* -> "
+                    "([A-Za-z_][A-Za-z0-9_]*\\.)*[A-Za-z_][A-Za-z0-9_]*$"
+                ),
+                "type": "string",
+            },
+        ]
+    },
+    "title": "Connections",
+    "type": "array",
+}
 
 
 class PortV1(BaseModel):
@@ -105,7 +135,9 @@ class RoutineV1(BaseModel):
     type: Optional[str] = None
     ports: Annotated[list[PortV1], _name_sorter] = Field(default_factory=list)
     resources: Annotated[list[ResourceV1], _name_sorter] = Field(default_factory=list)
-    connections: Annotated[list[ConnectionV1], _source_sorter] = Field(default_factory=list)
+    connections: Annotated[list[Annotated[ConnectionV1, _connection_parser]], _source_sorter] = Field(
+        default_factory=list
+    )
     input_params: list[_OptionallyMultiNamespacedName] = Field(default_factory=list)
     local_variables: dict[str, str] = Field(default_factory=dict)
     linked_params: Annotated[list[ParamLinkV1], _source_sorter] = Field(default_factory=list)
@@ -148,6 +180,7 @@ class _GenerateV1JsonSchema(GenerateJsonSchema):
         json_schema = super().generate(schema, mode=mode)
         json_schema["title"] = "FTQC-ready quantum program"
         json_schema["$schema"] = self.schema_dialect
+        json_schema["$defs"]["Routine"]["properties"]["connections"] = CONNECTION_SCHEMA
         return json_schema
 
     def normalize_name(self, name):

--- a/src/qref/schema_v1.py
+++ b/src/qref/schema_v1.py
@@ -34,7 +34,7 @@ NAME_PATTERN = "[A-Za-z_][A-Za-z0-9_]*"
 OPTIONALLY_NAMESPACED_NAME_PATTERN = rf"({NAME_PATTERN}\.)?{NAME_PATTERN}"
 MULTINAMESPACED_NAME_PATTERN = rf"({NAME_PATTERN}\.)+{NAME_PATTERN}"
 OPTIONALLY_MULTINAMESPACED_NAME_PATTERN = rf"({NAME_PATTERN}\.)*{NAME_PATTERN}"
-CONNECTON_PATTERN = rf"{OPTIONALLY_MULTINAMESPACED_NAME_PATTERN} -> {OPTIONALLY_MULTINAMESPACED_NAME_PATTERN}"
+CONNECTION_PATTERN = rf"{OPTIONALLY_MULTINAMESPACED_NAME_PATTERN} -> {OPTIONALLY_MULTINAMESPACED_NAME_PATTERN}"
 
 _Name = Annotated[str, StringConstraints(pattern=rf"^{NAME_PATTERN}$")]
 _OptionallyNamespacedName = Annotated[str, StringConstraints(pattern=rf"^{OPTIONALLY_NAMESPACED_NAME_PATTERN}$")]
@@ -72,10 +72,7 @@ CONNECTION_SCHEMA = {
         "anyOf": [
             {"$ref": "#/$defs/Connection"},
             {
-                "pattern": (
-                    "^([A-Za-z_][A-Za-z0-9_]*\\.)*[A-Za-z_][A-Za-z0-9_]* -> "
-                    "([A-Za-z_][A-Za-z0-9_]*\\.)*[A-Za-z_][A-Za-z0-9_]*$"
-                ),
+                "pattern": f"^{CONNECTION_PATTERN}$",
                 "type": "string",
             },
         ]

--- a/tests/qref/data/valid_programs/example_6.yaml
+++ b/tests/qref/data/valid_programs/example_6.yaml
@@ -1,0 +1,101 @@
+description: Program with concise connections
+input:
+  program:
+    children:
+    - name: child_1
+      ports:
+      - direction: input
+        name: in_0
+        size: 1
+      - direction: output
+        name: out_0
+        size: 1
+    - name: child_2
+      ports:
+      - direction: input
+        name: in_0
+        size: 1
+      - direction: output
+        name: out_0
+        size: 1
+    - name: child_3
+      ports:
+      - direction: input
+        name: in_0
+        size: 1
+      - direction: output
+        name: out_0
+        size: 1
+    - name: child_4
+      ports:
+      - direction: input
+        name: in_0
+        size: 1
+      - direction: output
+        name: out_0
+        size: 1
+    - name: child_5
+      ports:
+      - direction: input
+        name: in_0
+        size: 1
+      - direction: output
+        name: out_0
+        size: 1
+    - name: child_6
+      ports:
+      - direction: input
+        name: in_0
+        size: 1
+      - direction: input
+        name: in_1
+        size: 1
+      - direction: output
+        name: out_0
+        size: 1
+      - direction: output
+        name: out_1
+        size: 1
+    - name: child_7
+      ports:
+      - direction: input
+        name: in_0
+        size: 1
+      - direction: input
+        name: in_1
+        size: 1
+      - direction: output
+        name: out_0
+        size: 1
+
+    connections:
+    - "in_0 -> child_1.in_0"
+    - "in_1 -> child_4.in_0"
+    - "in_2 -> child_5.in_0"
+    - "child_1.out_0 -> child_2.in_0"
+    - "child_2.out_0 -> child_3.in_0"
+    - "child_3.out_0 -> out_0"
+    - "child_4.out_0 -> child_6.in_0"
+    - "child_5.out_0 -> child_6.in_1"
+    - "child_6.out_0 -> child_7.in_0"
+    - "child_6.out_1 -> child_7.in_1"
+    - "child_7.out_0 -> out_1"
+    name: root
+    ports:
+    - direction: input
+      name: in_0
+      size: 1
+    - direction: input
+      name: in_1
+      size: 1
+    - direction: input
+      name: in_2
+      size: 1
+    - direction: output
+      name: out_0
+      size: 1
+    - direction: output
+      name: out_1
+      size: 1
+
+  version: v1


### PR DESCRIPTION
## Description

Closes #12 

The concise format is "source -> target" (space-insensitive). It works both for schema validation and for pydantic model validation. However, for pydantic objects, the concise format always translates to original `ConnectionV1` object.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.