### PR TITLE
docs: Add `through` to available port directions

### DIFF
--- a/docs/format.md
+++ b/docs/format.md
@@ -86,7 +86,8 @@ Let us first take a look at ports, like the first input port of our program:
 
 Ports, like most other components in QREF, have names, which should be distinct
 among all ports of any given program (or subroutine). Each port also has
-direction, which can be either `input` or `output`. Finally, each port has size.
+direction, which can be either `input`, `output` or `through` (for ports serving as
+both input and output). Finally, each port has size.
 In our simple scenario, all sizes are positive integers. However, QREF
 is not limited to them, and size of a port can be either:
 

--- a/src/qref/functools.py
+++ b/src/qref/functools.py
@@ -18,9 +18,11 @@ from typing import Any, Callable, Concatenate, ParamSpec, TypeVar
 
 from .schema_v1 import RoutineV1, SchemaV1
 
+AnyQrefType = dict[str, Any] | SchemaV1 | RoutineV1
+
 
 @singledispatch
-def ensure_routine(data: dict[str, Any] | SchemaV1 | RoutineV1) -> RoutineV1:
+def ensure_routine(data: AnyQrefType) -> RoutineV1:
     """Ensure that given objects is of RoutineV1 type.
 
     This functions may serve for constructing functions accepting either RoutineV1 oor SchemaV1
@@ -57,9 +59,7 @@ P = ParamSpec("P")
 T = TypeVar("T")
 
 
-def accepts_all_qref_types(
-    f: Callable[Concatenate[RoutineV1, P], T]
-) -> Callable[Concatenate[SchemaV1 | RoutineV1 | dict[str, Any], P], T]:
+def accepts_all_qref_types(f: Callable[Concatenate[RoutineV1, P], T]) -> Callable[Concatenate[AnyQrefType, P], T]:
     """Make a callable accepting RoutineV1 as first arg capable of accepting arbitrary QREF object.
 
     Here, by arbitrary QREF object we mean either an instance of SchemaV1, an instance of RoutineV1,


### PR DESCRIPTION
## Description

This updates the docs to include `through` to available port directions.

Additionally, this PR introduces `AnyQrefType`, which should make it easier to type-hint uses of `ensure_routine`.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [ ] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.