### PR TITLE
fix: Fix topology verification

### DIFF
--- a/src/qref/schema_v1.py
+++ b/src/qref/schema_v1.py
@@ -208,7 +208,7 @@ class RoutineV1(BaseModel):
         if missed_ports:
             raise ValueError(
                 "The following ports appear in a connection but are not "
-                "among routine's port or their children's ports: {missed_ports}."
+                f"among routine's port or their children's ports: {missed_ports}."
             )
         return self
 

--- a/src/qref/verification.py
+++ b/src/qref/verification.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass
 from typing import Callable
 
 from .functools import accepts_all_qref_types
-from .schema_v1 import RoutineV1, SchemaV1
+from .schema_v1 import RoutineV1
 
 AdjacencyList = dict[str, list[str]]
 

--- a/src/qref/verification.py
+++ b/src/qref/verification.py
@@ -181,16 +181,16 @@ def _find_disconnected_ports(routine: RoutineV1, ancestor_path: tuple[str, ...])
             if port.direction != "input":
                 requiring_outgoing.add(pname)
 
-    for port in requiring_outgoing:
-        if port not in sources_counts:
-            problems.append(f"No outgoing connection from {_prefix(port)}.")
+    for pname in requiring_outgoing:
+        if pname not in sources_counts:
+            problems.append(f"No outgoing connection from {_prefix(pname)}.")
 
-    for port in requiring_incoming:
-        if port not in target_counts:
-            problems.append(f"No incoming connection to {_prefix(port)}.")
+    for pname in requiring_incoming:
+        if pname not in target_counts:
+            problems.append(f"No incoming connection to {_prefix(pname)}.")
 
-    for port in thru_ports:
-        if port in sources_counts or port in target_counts:
-            problems.append(f"A through port {_prefix(port)} is connected via an internal connection.")
+    for pname in thru_ports:
+        if pname in sources_counts or pname in target_counts:
+            problems.append(f"A through port {_prefix(pname)} is connected via an internal connection.")
 
     return problems

--- a/src/qref/verification.py
+++ b/src/qref/verification.py
@@ -162,7 +162,7 @@ def _find_disconnected_ports(routine: RoutineV1, ancestor_path: tuple[str, ...])
 
     requiring_outgoing = set[str]()
     requiring_incoming = set[str]()
-    cannot_be_connected = set[str]()
+    thru_ports = set[str]()
 
     for port in routine.ports:
         if port.direction == "input" and routine.children:
@@ -170,7 +170,7 @@ def _find_disconnected_ports(routine: RoutineV1, ancestor_path: tuple[str, ...])
         elif port.direction == "output" and routine.children:
             requiring_incoming.add(port.name)
         elif port.direction == "through":  # Note: through ports have to be valid regardless of existence of children
-            cannot_be_connected.add(port.name)
+            thru_ports.add(port.name)
 
     for child in routine.children:
         # Directions are reversed compared to parent + through ports have to be connected on both ends
@@ -189,7 +189,7 @@ def _find_disconnected_ports(routine: RoutineV1, ancestor_path: tuple[str, ...])
         if port not in target_counts:
             problems.append(f"No incoming connection to {_prefix(port)}.")
 
-    for port in cannot_be_connected:
+    for port in thru_ports:
         if port in sources_counts or port in target_counts:
             problems.append(f"A through port {_prefix(port)} is connected via an internal connection.")
 

--- a/tests/qref/data/invalid_topology_programs.yaml
+++ b/tests/qref/data/invalid_topology_programs.yaml
@@ -128,7 +128,23 @@
     version: v1
   description: Program has badly connected ports
   problems:
-  - "No incoming connections to root.child_1.in_1."
+  - "No incoming connection to root.child_1.in_1."
   - "Too many incoming connections to root.child_2.in_0."
   - "Too many outgoing connections from root.child_2.out_0."
-  - "No outgoing connections from root.child_2.out_1."
+  - "No outgoing connection from root.child_2.out_1."
+- input:
+    version: v1
+    program:
+      name: root
+      ports:
+        - direction: through
+          name: thru_0
+          size: 1
+        - direction: output
+          name: out_0
+          size: 1
+      connections:
+        - thru_0 -> out_0
+  description: "A routine with its thru port connected to its output port."
+  problems:
+    - "A through port root.thru_0 is connected via an internal connection."

--- a/tests/qref/data/invalid_topology_programs.yaml
+++ b/tests/qref/data/invalid_topology_programs.yaml
@@ -148,3 +148,45 @@
   description: "A routine with its thru port connected to its output port."
   problems:
     - "A through port root.thru_0 is connected via an internal connection."
+- input:
+    version: v1
+    program:
+      name: root
+      ports:
+        - direction: input
+          name: in_0
+          size: N
+        - direction: output
+          name: out_0
+          size: N
+        - direction: output
+          name: out_1
+          size: N
+      connections:
+        - in_0 -> foo.in_0
+        - foo.out_0 -> out_0
+        - foo.out_1 -> out_1
+      children:
+        - name: foo
+          ports:
+            - direction: input
+              name: in_0
+              size: N
+            - direction: output
+              name: out_0
+              size: N
+            - direction: output
+              name: out_1
+              size: N
+          connections:
+            - bar.out_0 -> out_1
+          children:
+            - name: bar
+              ports:
+                - name: out_0
+                  size: N
+                  direction: output
+  description: "Program with disconnected container ports"
+  problems:
+    - "No outgoing connection from root.foo.in_0."
+    - "No incoming connection to root.foo.out_0."

--- a/tests/qref/test_schema_validation.py
+++ b/tests/qref/test_schema_validation.py
@@ -44,3 +44,21 @@ def test_invalid_program_fails_to_validate_with_pydantic_model_v1(input):
 
 def test_valid_program_succesfully_validate_with_pydantic_model_v1(valid_program):
     SchemaV1.model_validate(valid_program)
+
+
+def test_validation_error_includes_name_of_the_missed_port():
+    input = {
+        "version": "v1",
+        "program": {
+            "name": "root",
+            "ports": [{"name": "in_0", "direction": "input", "size": 1}],
+            "connections": ["in_0 -> out_0"],
+        },
+    }
+
+    pattern = (
+        "The following ports appear in a connection but are not among routine's port "
+        r"or their children's ports: \['out_0'\]."  # <- out_0 is the important bit here
+    )
+    with pytest.raises(pydantic.ValidationError, match=pattern):
+        SchemaV1.model_validate(input)

--- a/tests/qref/test_topology_verification.py
+++ b/tests/qref/test_topology_verification.py
@@ -45,7 +45,6 @@ def test_correct_routines_pass_topology_validation(valid_program):
 def test_invalid_program_fails_to_validate_with_schema_v1(input, problems):
     verification_output = verify_topology(SchemaV1(**input))
 
-    assert not verification_output
-    assert len(problems) == len(verification_output.problems)
-    for expected_problem, problem in zip(problems, verification_output.problems):
-        assert expected_problem == problem
+    # We use sorted here, to make sure that we don't test the order in which the
+    # problems appear, as the order is only an implementation detail.
+    assert sorted(verification_output.problems) == sorted(problems)


### PR DESCRIPTION
## Description

Our topology verification did not take into account the through ports, and it also could malform the path at which the problem were reported. This PR fixes this issue. Additionally, this PR fixes an issue with malformed f-string occurring in `SchemaV1` validation.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.