### PR TITLE
feat: add visualization for repeated routines

### DIFF
--- a/src/qref/experimental/rendering.py
+++ b/src/qref/experimental/rendering.py
@@ -72,7 +72,6 @@ REPETITION_NODE_KWARGS = {
     "color": "#097969",  # Green border color
     "fontsize": "10",  # Smaller font size than the rest of the graph
     "shape": "record",
-
 }
 
 # Additional attributes of subgraphs of ports (ports of the same direction
@@ -148,14 +147,14 @@ def _add_nonleaf(routine, dag: graphviz.Digraph, parent_path: str) -> None:
                 _format_node_name(connection.source, routine, full_path),
                 _format_node_name(connection.target, routine, full_path),
             )
-        
+
         if routine.repetition is not None:
             label = "Repeated subroutine"
             repetition_type = routine.repetition.sequence.type
-            count = routine.repetition.count            
-            node_structure = f'{label} | {{type:   {repetition_type}}} | {{count:  {count}}}'
+            count = routine.repetition.count
+            node_structure = f"{label} | {{type:   {repetition_type}}} | {{count:  {count}}}"
             # Similarly to through ports, we add ghost nodes and edges to center repetition
-            cname = f'{full_path}_repetition'
+            cname = f"{full_path}_repetition"
             dummy_out = f"{cname}_out"
             dummy_in = f"{cname}_in"
             cluster.node(dummy_in, label="", style="invis")
@@ -164,7 +163,6 @@ def _add_nonleaf(routine, dag: graphviz.Digraph, parent_path: str) -> None:
             cluster.edge(cname, dummy_out, style="invis")
 
             cluster.node(cname, node_structure, **REPETITION_NODE_KWARGS)
-
 
 
 def _ports_row(ports) -> str:


### PR DESCRIPTION
## Description

Adds visualization to QREF subroutine with repetitions.

It looks like this:

<img width="733" alt="Screenshot 2024-12-30 at 6 22 45 PM" src="https://github.com/user-attachments/assets/aa254374-d70a-4e13-a257-c81186b36657" />

Code for repro (from `qref/tests/qref/data/valid_programs` directory):
```
import yaml
import glob
from qref.experimental.rendering import to_graphviz
paths = glob.glob("programs_with_repetitions/*")
valid_programs = []
for path in paths:
    with open(path) as f:
        data = yaml.safe_load(f)
        valid_programs.append(data["input"])
to_graphviz(valid_programs[0])
```

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix. (NA)
- [x] I have updated documentation. (NA)