### PR TITLE
feat: Preserve chronology of children when validating QREF

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -9,7 +9,7 @@ should have an unique name. This choice affects:
 - Children of a `Routine`.
 - Ports of a `Routine`.
 
-For instance, why did we chose to represent ports like this:
+For instance, why did we choose to represent ports like this:
 
 ```yaml
 ports:
@@ -24,9 +24,9 @@ ports:
   in_0: {"direction": "input", "size": 2}
   out_0: {"direction": "output", "size": "N"}
 ```
-?
+? There are two answers to this question.
 
-The answer is purely pragmatic. On the one hand, using mappings
+The first answer is purely pragmatic. On the one hand, using mappings
 instead of lists would guarantee uniqueness of names of ports
 and children. But, on the other hand, it would give a false
 sense of security. To see why, consider the following example
@@ -91,6 +91,18 @@ data format. Different users can use different parsers and we
 want to make sure everyone gets consistent results no matter
 what parsing library they use.
 
+The second reason concerns only `children` field and is much more nuanced,
+but essentially boils down to the fact that lists are naturally better suited
+for storing ordered information. While QREF format itself does not enforce
+ordering on the input data, there might be algorithms that
+utilize particular ordering of subroutines. Therefore, it is
+essential that at least the order of children is expressed in a list.
+
+!!! note
+
+    When constructing instances of QREF pydantic models, lists of ports and
+    resources are sorted alphabetically by name. However, initial order
+    of children is always preserved.
 
 ## Why isn't routine a top level object?
 
@@ -102,7 +114,7 @@ version: v1
 program:
   name: my_program
   children:
-    # ... 
+    # ...
 ```
 You might wonder why wouldn't we just make the program a
 top-level object, or, in other words, why don't QREF

--- a/src/qref/schema_v1.py
+++ b/src/qref/schema_v1.py
@@ -241,7 +241,7 @@ class RoutineV1(BaseModel):
     """
 
     name: _Name
-    children: Annotated[NamedList[RoutineV1], _name_sorter] = Field(default_factory=NamedList)
+    children: NamedList[RoutineV1] = Field(default_factory=NamedList)
     type: str | None = None
     ports: Annotated[NamedList[PortV1], _name_sorter] = Field(default_factory=NamedList)
     resources: Annotated[NamedList[ResourceV1], _name_sorter] = Field(default_factory=NamedList)

--- a/tests/qref/test_schema_validation.py
+++ b/tests/qref/test_schema_validation.py
@@ -67,15 +67,8 @@ def test_validation_error_includes_name_of_the_missed_port():
 def test_chronology_of_children_is_preserved_when_constructing_model_instances():
     # We used to sort children by name before we decided chronology is important. This test ensures that
     # we haven't unintentionally reintroduced this sorting again.
-    input = {
-        "version": "v1",
-        "program": {
-            "name": "test",
-            "children": [{"name": "c"}, {"name": "b"}, {"name": "d"}]
-        }
-    }
+    input = {"version": "v1", "program": {"name": "test", "children": [{"name": "c"}, {"name": "b"}, {"name": "d"}]}}
 
     qref_obj = SchemaV1.model_validate(input)
 
     assert [child.name for child in qref_obj.program.children] == ["c", "b", "d"]
-

--- a/tests/qref/test_schema_validation.py
+++ b/tests/qref/test_schema_validation.py
@@ -62,3 +62,20 @@ def test_validation_error_includes_name_of_the_missed_port():
     )
     with pytest.raises(pydantic.ValidationError, match=pattern):
         SchemaV1.model_validate(input)
+
+
+def test_chronology_of_children_is_preserved_when_constructing_model_instances():
+    # We used to sort children by name before we decided chronology is important. This test ensures that
+    # we haven't unintentionally reintroduced this sorting again.
+    input = {
+        "version": "v1",
+        "program": {
+            "name": "test",
+            "children": [{"name": "c"}, {"name": "b"}, {"name": "d"}]
+        }
+    }
+
+    qref_obj = SchemaV1.model_validate(input)
+
+    assert [child.name for child in qref_obj.program.children] == ["c", "b", "d"]
+


### PR DESCRIPTION
## Description

We need to preserve chronology of children when computing highwater in Bartiq. However, the chronology is lost when we perform validation of `RoutineV1`, because we sort children by name. This PR just removes the sorting.

Note that all other functionalities we have here and in Bartiq don't rely on chronology, so this change should be non-breaking.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.